### PR TITLE
Support HTTP Auth by setting the request header

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,6 +38,9 @@ var config = (function(window,document,undefined){
   // override userAgent if necessary
   config.userAgent = null;
 
+  // override request headers for HTTP Auth by setting the base64 encoded username:credentials here.
+  config.httpAuth = null;
+
   // uncomment this function to provide a callback for the data
   // config.cb = function(data) {
   // }

--- a/spider.js
+++ b/spider.js
@@ -21,14 +21,22 @@
 
   // ##################  WORKING CODE  #################
 
+  var settings = {
+    loadImages: config.loadImages,
+    loadPlugins: config.loadPlugins
+  }
+
+  if (config.httpAuth != null) {
+    settings.customHeaders = {
+      'Authorization': 'Basic ' + config.httpAuth
+    }
+  }
+
   // Create Casper
   var casper = require('casper').create({
     verbose: config.verbose,
     logLevel: config.logLevel,
-    pageSettings: {
-      loadImages: config.loadImages,
-      loadPlugins: config.loadPlugins
-    }
+    pageSettings: settings
   });
 
   // Echo options hash to screen
@@ -42,7 +50,7 @@
   var visitedUrls = [], pendingUrls = [], skippedUrls = [];
   var times = [];
   var visitedResourceUrls = [];
-  
+
   // required and skipped values
   var requiredValues = casper.cli.get('required-values') || config.requiredValues,
       skippedValues = casper.cli.get('skipped-values') || config.skippedValues,
@@ -93,7 +101,7 @@
 
     // Add the URL to visited stack
     visitedUrls.push(url);
-    
+
     // Add cookie
     if (dataObj.cookie) {
       casper.page.addCookie(dataObj.cookie);
@@ -232,7 +240,7 @@
     this.log('BACKTRACE:' + backtrace, 'WARNING');
     this.die('Crawl stopped because of errors.');
   });
-  
+
   // Find the longuest request
   casper.on('resource.requested', function(resource) {
       times[resource.id] = {
@@ -278,7 +286,7 @@
     if (typeof config.cb === 'function') {
       config.cb(data);
     }
-    
+
     // Find the longest request.
     var longest = times.sort(function(reqa, reqb) {
         return reqb.time - reqa.time;
@@ -286,7 +294,7 @@
     this.echo('', 'INFO');
     this.echo(utils.format('Longest request: %s (%s) with %dms', longest.url, longest.status, longest.time), 'INFO');
     this.echo('', 'INFO');
-    
+
     this.echo('Crawl has completed!', 'INFO');
     this.echo('Data file can be found at ' + filename + '.', 'INFO');
   });


### PR DESCRIPTION
This is an untested change to implement initial support for basic HTTP Auth by

- adding a new configuration option
- setting the header (restructured the settings code a bit) based on phantomJS best practices [1], [2]

Further improvement could be to provide the base64 encoding as well instead of assuming the `config.httpAuth` variable to be already encoded.

[1] https://github.com/casperjs/casperjs/issues/667
[2] https://holsson.wordpress.com/2016/02/04/adding-a-custom-http-header-using-casperjs/